### PR TITLE
Fix Firestore path for bookings to enable booking dates

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -240,7 +240,7 @@ export default function App() {
     useEffect(() => {
         if (isAuthReady && db) {
             const appId = typeof __app_id !== 'undefined' ? __app_id : 'default-app-id';
-            const bookingsCollectionPath = `/artifacts/${appId}/public/data/bookings`;
+            const bookingsCollectionPath = `artifacts/${appId}/public/data/bookings`;
             const q = query(collection(db, bookingsCollectionPath));
             const unsubscribe = onSnapshot(q, (querySnapshot) => {
                 const bookingsData = querySnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
@@ -263,7 +263,7 @@ export default function App() {
         if (getBookingForMonth(bookingDetails.month)) { setError('هذا الشهر محجوز بالفعل.'); return; }
         try {
             const appId = typeof __app_id !== 'undefined' ? __app_id : 'default-app-id';
-            const bookingsCollectionPath = `/artifacts/${appId}/public/data/bookings`;
+            const bookingsCollectionPath = `artifacts/${appId}/public/data/bookings`;
             const docId = `${hijriYear}_${bookingDetails.month}`;
             await setDoc(doc(db, bookingsCollectionPath, docId), { ...bookingDetails, year: hijriYear, createdAt: new Date() });
             setLatestBooking({ ...bookingDetails, year: hijriYear });


### PR DESCRIPTION
## Summary
- correct Firestore path for bookings by removing leading slash

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68beeafe43308332a8d2702d41705e0d